### PR TITLE
Fix timetable style

### DIFF
--- a/assets/css/timetable.css
+++ b/assets/css/timetable.css
@@ -42,7 +42,7 @@ ul.timetable {
 
 .timetable-session {
   position:relative;
-  min-width:400px;
+  min-width:80%;
   min-height:50px;
   background:#F50808;
   padding:30px;
@@ -91,11 +91,11 @@ ul.timetable {
   }
 
   .timetable-evnet {
-    font-size: 25px;
+    font-size: 22px;
   }
 
   .timetable-timebox {
-    font-size: 24px;
+    font-size: 23px;
   }
 
   .timetable-session-title {
@@ -109,7 +109,7 @@ ul.timetable {
   .timetable-session {
     margin-left: 10px;
     margin-right: 10px;
-    min-width:380px;
+    min-width:100%;
     min-height:30px;
     padding:15px;
   }


### PR DESCRIPTION
Timetableの修正でStyle崩れてたので修正
右端に空白できてた

## 修正前
![before_site](https://github.com/rubykansai/osaka03/assets/911903/723fa366-b5a8-4769-8431-cc9cedb40eca)

## 修正後
![after_site](https://github.com/rubykansai/osaka03/assets/911903/2a6174e3-5055-4bb2-9b6a-eb625490c9a3)
