### PR TITLE
Narrow the spacing between the text and logo on the about section

### DIFF
--- a/assets/css/about.css
+++ b/assets/css/about.css
@@ -12,7 +12,7 @@
 .round-button {
   display: grid;
   place-items: center;
-  margin: 0 2rem 0 auto;
+  margin: 0 0 0 auto;
   font-weight: 700;
   color: #e50808;
   text-decoration-line: none;
@@ -71,12 +71,17 @@
   .round-button {
     width: 9.5em;
     height: 3em;
-    margin: 5rem 5rem 0 auto;
+    margin: 5rem 0 0 auto;
     font-size: 1rem;
   }
 }
 
 @media (min-width: 1200px) {
+  .about {
+    padding: 9vw;
+    background-size: 18%;
+  }
+
   .about h1 {
     font-size: 4rem;
     line-height: 5.5rem;
@@ -87,10 +92,16 @@
     line-height: 1.5;
   }
 
+  .about p {
+    font-size: 1.5rem;
+    line-height: 2.5rem;
+  }
+
   .round-button {
     width: 9.5em;
     height: 3em;
     margin: 5rem 0 0 auto;
+    font-size: 1.5rem;
   }
 }
 


### PR DESCRIPTION
Fix: https://github.com/rubykansai/osaka03/issues/37

width: 1400px
![1400](https://github.com/rubykansai/osaka03/assets/13041216/c752dc8d-7945-4038-ac66-0fe14e1759b0)

width: 1200px
![1200](https://github.com/rubykansai/osaka03/assets/13041216/c52d9261-4a9e-403f-81b1-08bb196050e3)

width: 800px
![800](https://github.com/rubykansai/osaka03/assets/13041216/02280135-9d07-427e-bc79-11e64bb03d38)

width: 400px
![400](https://github.com/rubykansai/osaka03/assets/13041216/dcf4c95c-364d-44f3-b816-c1437c7b3ece)
